### PR TITLE
Fixing URL in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ The project is including the scripts to compile the application with maven and t
     
 **To run the application in browser:**
 
-    http://host-ip/rainy-hills/
+    http://host-ip/rainy-hills/calculate


### PR DESCRIPTION
New URL is http://host-ip/rainy-hills/calculate